### PR TITLE
RTSPClient: Only read RTSP response body if it exists

### DIFF
--- a/src/com/axis/rtspclient/RTSPClient.as
+++ b/src/com/axis/rtspclient/RTSPClient.as
@@ -207,12 +207,15 @@ package com.axis.rtspclient {
         return false;
       }
 
-      if (data.bytesAvailable < parsed.headers['content-length']) {
-        return false;
+      if (parsed.headers['content-length']) {
+        if (data.bytesAvailable < parsed.headers['content-length']) {
+          return false;
+        }
+
+        /* RTSP commands contain no heavy body, so it's safe to read everything */
+        data.readBytes(oBody, 0, parsed.headers['content-length']);
       }
 
-      /* RTSP commands contain no heavy body, so it's safe to read everything */
-      data.readBytes(oBody, 0, parsed.headers['content-length']);
       requestReset();
       return parsed;
     }


### PR DESCRIPTION
Only read the RTSP response body if the 'Content-Length' header
is set. Otherwise there is a risk that we read and discard
initial video data.
