### PR TITLE
Corrected data pushing logic

### DIFF
--- a/src/com/axis/rtspclient/FLVMux.as
+++ b/src/com/axis/rtspclient/FLVMux.as
@@ -50,6 +50,8 @@ package com.axis.rtspclient {
       if (sdp.getMediaBlock('audio')) {
         createAudioSpecificConfigTag(ByteArrayUtils.createFromHexstring(sdp.getMediaBlock('audio').fmtp['config']));
       }
+
+      pushData();
     }
 
     private function writeECMAArray(contents:Object):uint

--- a/src/com/axis/rtspclient/NALU.as
+++ b/src/com/axis/rtspclient/NALU.as
@@ -43,16 +43,9 @@ package com.axis.rtspclient {
 
     public function writeStream(output:ByteArray):void
     {
-      /* NALU of type STAP-B */
-      output.writeShort(0x0000); // DON
-      output.writeShort(data.bytesAvailable + 1); // NALU length + header
+      output.writeUnsignedInt(data.bytesAvailable + 1); // NALU length + header
       output.writeByte((0x0 & 0x80) | (nri & 0x60) | (ntype & 0x1F)); // NAL header
       output.writeBytes(data, data.position);
-    }
-
-    public function getPayload():ByteArray
-    {
-      return data;
     }
   }
 }


### PR DESCRIPTION
- NALU; use 4 bytes to describe size. Using only 2 bytes would
  overflow if a NALU was larger than 0xffff, which is common
  for reference picture when resolution is in the full-hd ranges.
- FLVMux; push the metadata tag so it isn't mistaken for the
  beginning of a video/audio tag.
- Removed unused function.
