### PR TITLE
RTSPClient: Wait for full interleaved header

### DIFF
--- a/src/com/axis/rtspclient/RTSPClient.as
+++ b/src/com/axis/rtspclient/RTSPClient.as
@@ -321,6 +321,12 @@ package com.axis.rtspclient {
     {
       handle.readBytes(data, data.length);
 
+      if (data.bytesAvailable < 4) {
+        /* Not enough data even for interleaved header. Try again when
+           more data is available */
+        return;
+      }
+
       if (-1 == rtpLength && 0x24 === data[0]) {
         /* This is the beginning of a new RTP package */
         data.readByte();


### PR DESCRIPTION
If the interleaved header has been chunked, we generally
have to wait for the full header to arrive before we can
extract any useful information from it.
