### PR TITLE
RTMPClient: Honor port

### DIFF
--- a/src/com/axis/http/url.as
+++ b/src/com/axis/http/url.as
@@ -39,7 +39,9 @@ package com.axis.http {
       ret.user = userpass[0];
       ret.pass = userpass[1];
       ret.host = hostport[0];
+
       ret.port = (null == hostport[1]) ? protocolDefaultPort(ret.protocol) : hostport[1];
+      ret.portDefined = (null != hostport[1]);
 
       return ret;
     }
@@ -52,6 +54,7 @@ package com.axis.http {
     private static function protocolDefaultPort(protocol:String):uint
     {
       switch (protocol) {
+        case 'rtmp': return 1935;
         case 'rtsp': return 554;
         case 'http': return 80;
         case 'https': return 443;

--- a/src/com/axis/rtmpclient/RTMPClient.as
+++ b/src/com/axis/rtmpclient/RTMPClient.as
@@ -30,9 +30,12 @@ package com.axis.rtmpclient {
       nc.addEventListener(AsyncErrorEvent.ASYNC_ERROR, asyncErrorHandler);
       nc.client = this;
 
-
       this.streamId = urlParsed.basename;
-      this.streamServer = urlParsed.protocol + '://' + urlParsed.host + urlParsed.basepath;
+      this.streamServer  = urlParsed.protocol + '://';
+      this.streamServer += urlParsed.host;
+      this.streamServer += ((urlParsed.portDefined) ? (':' + urlParsed.port) : '')
+      this.streamServer += urlParsed.basepath;
+      trace(this.streamServer);
 
       trace('RTMPClient: connecting to server: \'' + streamServer + '\'');
       nc.connect(streamServer);
@@ -90,4 +93,3 @@ package com.axis.rtmpclient {
     }
   }
 }
-


### PR DESCRIPTION
If a port is specified, connect to that port. If port is not specified,
it's important to leave it out of the URL (e.g. not to use the default 1935).
If the port is left out, NetStream will attempt different ways to reach the
server, both by RTMP and RTMPT on different ports.
