### PR TITLE
Redirect auth errors

### DIFF
--- a/src/com/axis/ErrorManager.as
+++ b/src/com/axis/ErrorManager.as
@@ -84,18 +84,20 @@ package com.axis {
       '732': "Socket reported an IOError: %p.",
       '800': "Unable to pause a stream if not playing.",
       '801': "Unable to resume a stream if not paused.",
-      '803': "Unable to pause: %p",
-      '804': "RTSPClient: Handle unexpectedly closed.",
-      '805': "Unknown determining byte: 0x%p. Stopping stream.",
-      '806': "Cannot start unless in initial state.",
-      '807': "Authorization to %p failed. Please check the username and password.",
-      '809': "RTSPClient:Failed to parse SDP file.",
-      '810': "No tracks in SDP file.",
-      '811': "Unable to pause. No active stream.",
-      '812': "Unable to resume. No active stream.",
-      '813': "Unable to stop. No active stream.",
-      '814': "Unknown streaming protocol: %p",
-      '815': "Unsupported audio transmit protocol."
+      '802': "Unable to pause: %p",
+      '803': "RTSPClient: Handle unexpectedly closed.",
+      '804': "Unknown determining byte: 0x%p. Stopping stream.",
+      '805': "Cannot start unless in initial state.",
+      '806': "RTSPClient:Failed to parse SDP file.",
+      '807': "No tracks in SDP file.",
+      '808': "Unable to pause. No active stream.",
+      '809': "Unable to resume. No active stream.",
+      '810': "Unable to stop. No active stream.",
+      '811': "Unknown streaming protocol: %p",
+      '812': "Unsupported audio transmit protocol.",
+      '813': "Denied access to microphone.",
+      '814': "Already connected to microphone.",
+      '815': "No audio transmit url provided."
     };
 
     public static function dispatchError(errorCode:Number, errorData:Array = null):void {

--- a/src/com/axis/rtspclient/RTSPClient.as
+++ b/src/com/axis/rtspclient/RTSPClient.as
@@ -201,7 +201,7 @@ package com.axis.rtspclient {
         authOpts = parsed.headers['www-authenticate'];
         var newAuthState:String = auth.nextMethod(authState, authOpts);
         if (authState === newAuthState) {
-          ErrorManager.dispatchError(807, [urlParsed.host]);
+          ErrorManager.dispatchError(parsed.code);
           dispatchEvent(new ClientEvent(ClientEvent.ABORTED));
           return false;
         }

--- a/src/com/axis/rtspclient/RTSPoverHTTPHandle.as
+++ b/src/com/axis/rtspclient/RTSPoverHTTPHandle.as
@@ -126,17 +126,15 @@ package com.axis.rtspclient {
     private function onGetChannelData(event:ProgressEvent):void {
       var parsed:* = request.readHeaders(getChannel, getChannelData);
       if (false === parsed) {
-        ErrorManager.dispatchError(807, [urlParsed.host]);
-        dispatchEvent(new ClientEvent(ClientEvent.ABORTED));
         return;
       }
 
       if (401 === parsed.code) {
-        trace('Unauthorized using auth method: ' + authState);
-        /* Unauthorized, change authState and (possibly) try again */
         authOpts = parsed.headers['www-authenticate'];
         var newAuthState:String = auth.nextMethod(authState, authOpts);
         if (authState === newAuthState) {
+          ErrorManager.dispatchError(parsed.code);
+          dispatchEvent(new ClientEvent(ClientEvent.ABORTED));
           return;
         }
 


### PR DESCRIPTION
Auth errors are now dispatched as the default 401 RTSP error instead of a custom Locomote error.
