### PR TITLE
Changed off API function

### DIFF
--- a/jslib/locomote.js
+++ b/jslib/locomote.js
@@ -210,13 +210,14 @@ Locomote.prototype = {
 
     this.callbacks.forEach(function(element, index, array) {
       if (element.callback === callback) {
-        if ((undefined === eventName) || (null === eventName) || (element.eventName === eventName)) {
+        if (!eventName || (element.eventName === eventName)) {
           array.splice(index, 1);
+          return;
         }
       }
 
       if (element.eventName === eventName) {
-        if ((undefined === callback) || (null === callback) || (element.callback === callback)) {
+        if (!callback || (element.callback === callback)) {
           array.splice(index, 1);
         }
       }


### PR DESCRIPTION
The `off` function now accepts either one or two parameters or none at all. Event listeners will be removed according to which parameters are provided. If you call `off` with no parameters, all listeners will be removed from the player.
