### PR TITLE
FLVMux: Parse chroma/luma params (not scaling matrix though)

### DIFF
--- a/src/com/axis/ErrorManager.as
+++ b/src/com/axis/ErrorManager.as
@@ -104,7 +104,7 @@ package com.axis {
       '819': "BitArray: Bit ranges must be 1 - 32.",
       '820': "BitArray: exp-golomb larger than 32 bits is unsupported.",
       '821': "ByteArray: Unsupported Pattern",
-      '822': "FLVMux: No support for parsing Chroma/Luma parameters",
+      '822': "FLVMux: No support for Chroma/Luma scaling matrix",
       '823': "FLVMux: No support for parsing 'pic_order_cnt_type' != 0",
       '824': "RTSPClient: Unable to determine control URL.",
       '825': "RTSPClient: Pause is not supported by server.",

--- a/src/com/axis/rtspclient/FLVMux.as
+++ b/src/com/axis/rtspclient/FLVMux.as
@@ -108,14 +108,31 @@ package com.axis.rtspclient {
 
     private function parseSPS(sps:BitArray):Object {
       var nalhdr:uint      = sps.readBits(8);
+
       var profile:uint     = sps.readBits(8);
+      Logger.log('FLVMux: sps profile =', profile);
+
       var constraints:uint = sps.readBits(8);
+      Logger.log('FLVMUX: sps constraints =', constraints);
+
       var level:uint       = sps.readBits(8);
+      Logger.log('FLVMux: sps level =', level);
 
       var seq_parameter_set_id:uint = sps.readUnsignedExpGolomb();
       if (-1 !== [100, 110, 122, 244, 44, 83, 86, 118, 128, 138].indexOf(profile)) {
         /* Parse chroma/luma parameters */
-        ErrorManager.dispatchError(822, null, true);
+        var chroma_format_idc:uint = sps.readUnsignedExpGolomb();
+        if (3 === chroma_format_idc) {
+          var separate_colour_plane_flag:uint = sps.readBits(1);
+        }
+
+        var bit_depth_luma_minus8:uint = sps.readUnsignedExpGolomb();
+        var bit_depth_chroma_minus8:uint = sps.readUnsignedExpGolomb();
+        var qpprime_y_zero_transform_bypass_flag:uint = sps.readBits(1);
+        var seq_scaling_matrix_present_flag:uint = sps.readBits(1);
+        if (1 === seq_scaling_matrix_present_flag) {
+          ErrorManager.dispatchError(822, null, true);
+        }
       }
 
       var log2_max_frame_num_minus4:uint = sps.readUnsignedExpGolomb();
@@ -171,6 +188,7 @@ package com.axis.rtspclient {
       spsdec.decode(sets[0]);
       var sps:BitArray = new BitArray(spsdec.toByteArray());
       var params:Object = parseSPS(sps);
+      Logger.log('FLVMux: stream params = ', params);
 
       /* Arguments */
       size += writeECMAArray({


### PR DESCRIPTION
Streams with higher h264 profile contain chroma/luma parameters.
Parse these correctly.

Change-Id: I9317929751efb0226ac9cd683268fdb05059467c
