### PR TITLE
RTSPClient auth: do not fall if authOpts.stale is null

### DIFF
--- a/src/com/axis/rtspclient/RTSPClient.as
+++ b/src/com/axis/rtspclient/RTSPClient.as
@@ -221,7 +221,7 @@ package com.axis.rtspclient {
         /* Unauthorized, change authState and (possibly) try again */
         authOpts = parsed.headers['www-authenticate'];
 
-        if (authOpts.stale.toUpperCase() === 'TRUE') {
+        if (authOpts.stale && authOpts.stale.toUpperCase() === 'TRUE') {
           requestReset();
           prevMethod();
           return false;


### PR DESCRIPTION
Hi! When trying to authorize RTSP stream with Gstreamer RTSP server client silently falls cause there is not "stale" header in authOpts. So, a little patch to fix this issue.