### PR TITLE
chaining for on and off methods in js lib

### DIFF
--- a/jslib/locomote.js
+++ b/jslib/locomote.js
@@ -191,6 +191,7 @@
 
     config: function(config) {
       this.e.setConfig(config);
+      return this;
     },
 
     on: function(eventName, callback) {
@@ -199,6 +200,7 @@
       if (eventName === 'apiReady' && this.swfready) {
         callback.call();
       }
+	  return this;
     },
 
     off: function(eventName, callback) {
@@ -221,6 +223,7 @@
           }
         }
       });
+	  return this;
     },
 
     __playerEvent: function(eventName /* ... args */) {

--- a/jslib/locomote.js
+++ b/jslib/locomote.js
@@ -200,20 +200,20 @@
       if (eventName === 'apiReady' && this.swfready) {
         callback.call();
       }
-	  return this;
+      return this;
     },
 
     off: function(eventName, callback) {
       if (!eventName && !callback) {
         this.callbacks = [];
-        return;
+        return this;
       }
 
       this.callbacks.forEach(function(element, index, array) {
         if (element.callback === callback) {
           if (!eventName || (element.eventName === eventName)) {
             array.splice(index, 1);
-            return;
+            return this;
           }
         }
 
@@ -223,7 +223,7 @@
           }
         }
       });
-	  return this;
+      return this;
     },
 
     __playerEvent: function(eventName /* ... args */) {

--- a/src/Player.as
+++ b/src/Player.as
@@ -168,6 +168,8 @@ package {
           } else {
             config.buffer = iconfig.buffer;
           }
+        } else {
+            config.buffer = iconfig.buffer;
         }
       }
 
@@ -251,7 +253,7 @@ package {
         ErrorManager.dispatchError(811, [urlParsed.protocol])
         return;
       }
-
+        
       addChild(this.client.getDisplayObject());
 
       client.addEventListener(ClientEvent.STOPPED, onStopped);


### PR DESCRIPTION
It's very convenient and cleaner to chain player events like this: player.on(evt1,cb1).on(evt2,cb2). So another little patch included.
