### PR TITLE
Use element id for tag name when passing DOM element in constructor

### DIFF
--- a/jslib/locomote.js
+++ b/jslib/locomote.js
@@ -15,7 +15,7 @@
 (this, function() {
   'use strict';
 
-  function get_tag_id(tag){
+  function getTagId(tag){
     if (('string' === typeof tag)) {
       return tag;
     } else if (tag instanceof HTMLElement) {
@@ -33,20 +33,20 @@
       window.LocomoteMap = {};
     }
 
-    this.tag_id = get_tag_id(tag);
+    this.tagId = getTagId(tag);
     // Instance already initialized. Return it.
-    if (window.LocomoteMap[ this.tag_id ]) {
-      return window.LocomoteMap[ this.tag_id ];
+    if (window.LocomoteMap[ this.tagId ]) {
+      return window.LocomoteMap[ this.tagId ];
     }
 
     // return a new Locomote object if we're in the global scope
     if (this === undefined) {
-      window.LocomoteMap[ this.tag_id ] = new Locomote(tag, swf);
-      return window.LocomoteMap[ this.tag_id ];
+      window.LocomoteMap[ this.tagId ] = new Locomote(tag, swf);
+      return window.LocomoteMap[ this.tagId ];
     }
 
     // Init our element object and return the object
-    window.LocomoteMap[ this.tag_id ] = this;
+    window.LocomoteMap[ this.tagId ] = this;
     this.callbacks = [];
     this.swfready = false;
     this.__embed(tag, swf);
@@ -73,7 +73,7 @@
         'class="locomote-player" ' +
         'data="' + swf + '" ' +
         'id="' + tempTag + '" ' +
-        'name="' + this.tag_id + '" ' +
+        'name="' + this.tagId + '" ' +
         'width="100%" ' +
         'height="100%" ' +
         'allowFullScreen="true">';
@@ -85,10 +85,10 @@
         allowscriptaccess: 'always',
         wmode: 'transparent',
         quality: 'high',
-        flashvars: 'locomoteID=' + this.tag_id,
+        flashvars: 'locomoteID=' + this.tagId,
         allowFullScreenInteractive: true,
         movie: swf,
-        name: get_tag_id(tag)
+        name: getTagId(tag)
       };
 
       for (var index in opts) {
@@ -245,7 +245,7 @@
     },
 
     destroy: function() {
-      window.LocomoteMap[ get_tag_id(this.tag) ] = undefined;
+      window.LocomoteMap[ this.tagId ] = undefined;
       this.e.parentNode.removeChild(this.e);
       this.e = null;
     }

--- a/jslib/locomote.js
+++ b/jslib/locomote.js
@@ -15,6 +15,15 @@
 (this, function() {
   'use strict';
 
+    function get_tag_id(tag){
+        if (('string' === typeof tag)){
+            return tag;
+        } else if (tag instanceof HTMLElement) {
+            return tag.getAttribute('id');
+        }
+        return 'unknown';
+    }
+
   function Locomote(tag, swf) {
     if (!tag) {
       return null;
@@ -25,18 +34,18 @@
     }
 
     // Instance already initialized. Return it.
-    if (window.LocomoteMap[tag]) {
-      return window.LocomoteMap[tag];
+    if (window.LocomoteMap[get_tag_id(tag)]) {
+      return window.LocomoteMap[get_tag_id(tag)];
     }
 
     // return a new Locomote object if we're in the global scope
     if (this === undefined) {
-      window.LocomoteMap[tag] = new Locomote(tag, swf);
-      return window.LocomoteMap[tag];
+      window.LocomoteMap[get_tag_id(tag)] = new Locomote(tag, swf);
+      return window.LocomoteMap[get_tag_id(tag)];
     }
 
     // Init our element object and return the object
-    window.LocomoteMap[tag] = this;
+    window.LocomoteMap[get_tag_id(tag)] = this;
     this.callbacks = [];
     this.swfready = false;
     this.__embed(tag, swf);
@@ -63,7 +72,7 @@
         'class="locomote-player" ' +
         'data="' + swf + '" ' +
         'id="' + tempTag + '" ' +
-        'name="' + tag + '" ' +
+        'name="' + get_tag_id(tag) + '" ' +
         'width="100%" ' +
         'height="100%" ' +
         'allowFullScreen="true">';
@@ -75,10 +84,10 @@
         allowscriptaccess: 'always',
         wmode: 'transparent',
         quality: 'high',
-        flashvars: 'locomoteID=' + tag,
+        flashvars: 'locomoteID=' + get_tag_id(tag),
         allowFullScreenInteractive: true,
         movie: swf,
-        name: tag
+        name: get_tag_id(tag)
       };
 
       for (var index in opts) {

--- a/jslib/locomote.js
+++ b/jslib/locomote.js
@@ -244,7 +244,7 @@
     },
 
     destroy: function() {
-      window.LocomoteMap[this.tag] = undefined;
+      window.LocomoteMap[get_tag_id(this.tag)] = undefined;
       this.e.parentNode.removeChild(this.e);
       this.e = null;
     }

--- a/jslib/locomote.js
+++ b/jslib/locomote.js
@@ -15,14 +15,14 @@
 (this, function() {
   'use strict';
 
-    function get_tag_id(tag){
-        if (('string' === typeof tag)){
-            return tag;
-        } else if (tag instanceof HTMLElement) {
-            return tag.getAttribute('id');
-        }
-        return 'unknown';
+  function get_tag_id(tag){
+    if (('string' === typeof tag)) {
+      return tag;
+    } else if (tag instanceof HTMLElement) {
+      return tag.getAttribute('id');
     }
+    return 'unknown';
+  }
 
   function Locomote(tag, swf) {
     if (!tag) {
@@ -33,19 +33,20 @@
       window.LocomoteMap = {};
     }
 
+    this.tag_id = get_tag_id(tag);
     // Instance already initialized. Return it.
-    if (window.LocomoteMap[get_tag_id(tag)]) {
-      return window.LocomoteMap[get_tag_id(tag)];
+    if (window.LocomoteMap[ this.tag_id ]) {
+      return window.LocomoteMap[ this.tag_id ];
     }
 
     // return a new Locomote object if we're in the global scope
     if (this === undefined) {
-      window.LocomoteMap[get_tag_id(tag)] = new Locomote(tag, swf);
-      return window.LocomoteMap[get_tag_id(tag)];
+      window.LocomoteMap[ this.tag_id ] = new Locomote(tag, swf);
+      return window.LocomoteMap[ this.tag_id ];
     }
 
     // Init our element object and return the object
-    window.LocomoteMap[get_tag_id(tag)] = this;
+    window.LocomoteMap[ this.tag_id ] = this;
     this.callbacks = [];
     this.swfready = false;
     this.__embed(tag, swf);
@@ -72,7 +73,7 @@
         'class="locomote-player" ' +
         'data="' + swf + '" ' +
         'id="' + tempTag + '" ' +
-        'name="' + get_tag_id(tag) + '" ' +
+        'name="' + this.tag_id + '" ' +
         'width="100%" ' +
         'height="100%" ' +
         'allowFullScreen="true">';
@@ -84,7 +85,7 @@
         allowscriptaccess: 'always',
         wmode: 'transparent',
         quality: 'high',
-        flashvars: 'locomoteID=' + get_tag_id(tag),
+        flashvars: 'locomoteID=' + this.tag_id,
         allowFullScreenInteractive: true,
         movie: swf,
         name: get_tag_id(tag)
@@ -92,7 +93,7 @@
 
       for (var index in opts) {
         if (opts.hasOwnProperty(index)) {
-          element += '<param name="' + index + '" value="' + opts[index] + '"/>';
+          element += '<param name="' + index + '" value="' + opts[ index ] + '"/>';
         }
       }
 
@@ -112,8 +113,8 @@
         var players = tag.getElementsByClassName('locomote-player');
 
         for (var i = 0; i < players.length; i++) {
-          if (players[i].getAttribute('id') === tempTag) {
-            this.e = players[i];
+          if (players[ i ].getAttribute('id') === tempTag) {
+            this.e = players[ i ];
             break;
           }
         }
@@ -244,7 +245,7 @@
     },
 
     destroy: function() {
-      window.LocomoteMap[get_tag_id(this.tag)] = undefined;
+      window.LocomoteMap[ get_tag_id(this.tag) ] = undefined;
       this.e.parentNode.removeChild(this.e);
       this.e = null;
     }

--- a/jslib/locomote.js
+++ b/jslib/locomote.js
@@ -16,12 +16,12 @@
   'use strict';
 
   function getTagId(tag){
-    if (('string' === typeof tag)) {
+    if ('string' === typeof tag) {
       return tag;
     } else if (tag instanceof HTMLElement) {
       return tag.getAttribute('id');
     }
-    return 'unknown';
+    throw new Exception("failed to initialize player: invaid container tag specified");
   }
 
   function Locomote(tag, swf) {
@@ -35,14 +35,14 @@
 
     this.tagId = getTagId(tag);
     // Instance already initialized. Return it.
-    if (window.LocomoteMap[ this.tagId ]) {
-      return window.LocomoteMap[ this.tagId ];
+    if (window.LocomoteMap[this.tagId]) {
+      return window.LocomoteMap[this.tagId];
     }
 
     // return a new Locomote object if we're in the global scope
     if (this === undefined) {
-      window.LocomoteMap[ this.tagId ] = new Locomote(tag, swf);
-      return window.LocomoteMap[ this.tagId ];
+      window.LocomoteMap[this.tagId] = new Locomote(tag, swf);
+      return window.LocomoteMap[this.tagId];
     }
 
     // Init our element object and return the object
@@ -113,8 +113,8 @@
         var players = tag.getElementsByClassName('locomote-player');
 
         for (var i = 0; i < players.length; i++) {
-          if (players[ i ].getAttribute('id') === tempTag) {
-            this.e = players[ i ];
+          if (players[i].getAttribute('id') === tempTag) {
+            this.e = players[i];
             break;
           }
         }
@@ -245,7 +245,7 @@
     },
 
     destroy: function() {
-      window.LocomoteMap[ this.tagId ] = undefined;
+      window.LocomoteMap[this.tagId] = undefined;
       this.e.parentNode.removeChild(this.e);
       this.e = null;
     }


### PR DESCRIPTION
If you pass DOM element in Locomote(tag,swf) constructor an [objet Object] name will be used for mapping. This is not correct behaviour cause two players passed by containers can overlap each other. A little fix for this problem is in this commits. It tooks id from container and maps players depending on this value. 
It's not fully correct to do this cause players without id still can be rewritable. This can be avoided by using ES6 Maps and hashes for id used in swf parameters but it can break compatibility with older browsers so patch is not included
