### PR TITLE
Fix parameters parsing problem in RTSPClient with Vivotek cameras

### DIFF
--- a/src/Player.as
+++ b/src/Player.as
@@ -39,7 +39,7 @@ package {
     [Embed(source = "../VERSION", mimeType = "application/octet-stream")] private var Version:Class;
 
     public static var locomoteID:String = null;
-    public static var debugLogger:Boolean = false;
+//    public static var debugLogger:Boolean = false; //not used
 
     private static const EVENT_STREAM_STARTED:String  = "streamStarted";
     private static const EVENT_STREAM_PAUSED:String  = "streamPaused";

--- a/src/Player.as
+++ b/src/Player.as
@@ -39,7 +39,6 @@ package {
     [Embed(source = "../VERSION", mimeType = "application/octet-stream")] private var Version:Class;
 
     public static var locomoteID:String = null;
-//    public static var debugLogger:Boolean = false; //not used
 
     private static const EVENT_STREAM_STARTED:String  = "streamStarted";
     private static const EVENT_STREAM_PAUSED:String  = "streamPaused";

--- a/src/com/axis/Logger.as
+++ b/src/com/axis/Logger.as
@@ -5,7 +5,7 @@ package com.axis {
     public static const STREAM_ERRORS:String = "";
 
     public static function log(... args):void {
-      if (Player.debugLogger) {
+      if (Player.config.debugLogger) {
         trace.apply(null, args);
       }
 

--- a/src/com/axis/rtspclient/RTSPClient.as
+++ b/src/com/axis/rtspclient/RTSPClient.as
@@ -312,8 +312,8 @@ package com.axis.rtspclient {
         if (state === STATE_SETUP) {
           /* this is not the case when falling through, e.g. SETUP of first track */
           if (!(/^RTP\/AVP\/TCP;/.test(parsed.headers["transport"]) &&
-        	/unicast/.test(parsed.headers["transport"]) &&
-        	/interleaved=/.test(parsed.headers["transport"]) )){
+	    /unicast/.test(parsed.headers["transport"]) &&
+            /interleaved=/.test(parsed.headers["transport"]) )){
             dispatchEvent(new ClientEvent(ClientEvent.STOPPED));
             connectionBroken = true;
             handle.disconnect();

--- a/src/com/axis/rtspclient/RTSPClient.as
+++ b/src/com/axis/rtspclient/RTSPClient.as
@@ -312,8 +312,8 @@ package com.axis.rtspclient {
         if (state === STATE_SETUP) {
           /* this is not the case when falling through, e.g. SETUP of first track */
           if (!(/^RTP\/AVP\/TCP;/.test(parsed.headers["transport"]) &&
-        	/unicast/.test(parsed.headers["transport"]) &&
-        	/interleaved=/.test(parsed.headers["transport"]) )){
+            /unicast/.test(parsed.headers["transport"]) &&
+            /interleaved=/.test(parsed.headers["transport"]) )){
             dispatchEvent(new ClientEvent(ClientEvent.STOPPED));
             connectionBroken = true;
             handle.disconnect();

--- a/src/com/axis/rtspclient/RTSPClient.as
+++ b/src/com/axis/rtspclient/RTSPClient.as
@@ -312,8 +312,8 @@ package com.axis.rtspclient {
         if (state === STATE_SETUP) {
           /* this is not the case when falling through, e.g. SETUP of first track */
           if (!(/^RTP\/AVP\/TCP;/.test(parsed.headers["transport"]) &&
-	    /unicast/.test(parsed.headers["transport"]) &&
-            /interleaved=/.test(parsed.headers["transport"]) )){
+        	/unicast/.test(parsed.headers["transport"]) &&
+        	/interleaved=/.test(parsed.headers["transport"]) )){
             dispatchEvent(new ClientEvent(ClientEvent.STOPPED));
             connectionBroken = true;
             handle.disconnect();

--- a/src/com/axis/rtspclient/RTSPClient.as
+++ b/src/com/axis/rtspclient/RTSPClient.as
@@ -311,7 +311,9 @@ package com.axis.rtspclient {
 
         if (state === STATE_SETUP) {
           /* this is not the case when falling through, e.g. SETUP of first track */
-          if (!/RTP\/AVP\/TCP;unicast;interleaved=/.test(parsed.headers["transport"])) {
+          if (!(/^RTP\/AVP\/TCP;/.test(parsed.headers["transport"]) &&
+        	/unicast;/.test(parsed.headers["transport"]) &&
+        	/interleaved=/.test(parsed.headers["transport"]) )){
             dispatchEvent(new ClientEvent(ClientEvent.STOPPED));
             connectionBroken = true;
             handle.disconnect();

--- a/src/com/axis/rtspclient/RTSPClient.as
+++ b/src/com/axis/rtspclient/RTSPClient.as
@@ -312,7 +312,7 @@ package com.axis.rtspclient {
         if (state === STATE_SETUP) {
           /* this is not the case when falling through, e.g. SETUP of first track */
           if (!(/^RTP\/AVP\/TCP;/.test(parsed.headers["transport"]) &&
-        	/unicast;/.test(parsed.headers["transport"]) &&
+        	/unicast/.test(parsed.headers["transport"]) &&
         	/interleaved=/.test(parsed.headers["transport"]) )){
             dispatchEvent(new ClientEvent(ClientEvent.STOPPED));
             connectionBroken = true;


### PR DESCRIPTION
Some cameras like Vivotek send parameters *unicast* and *interleaved* in different order. It causes problem in RTSPClient STATE_SETUP. 
Trying to fit this found another error with debugLogger. When set this flag from javascript with
`locomote.config( { "debugLogger": true } );` 
it changes Player::config.debugLogger , but com/axis/Logger is checking Player::debugLogger which is hardcoded. I've fixed this also.
