### PR TITLE
handle seq_scaling_matrix_present_flag

### DIFF
--- a/src/com/axis/rtspclient/BitArray.as
+++ b/src/com/axis/rtspclient/BitArray.as
@@ -48,5 +48,15 @@ package com.axis.rtspclient {
 
       return n - 1; /* Because result in exp golomb is one larger */
     }
+    
+    private function readSignedExpGolomb(sps:BitArray):uint {
+        var r:uint = this.readUnsignedExpGolomb();
+        if (r & 0x01) {
+            r = (r+1) >> 1;
+        } else {
+            r = -(r >> 1);
+        }
+        return r;
+    }
   }
 }

--- a/src/com/axis/rtspclient/BitArray.as
+++ b/src/com/axis/rtspclient/BitArray.as
@@ -49,7 +49,7 @@ package com.axis.rtspclient {
       return n - 1; /* Because result in exp golomb is one larger */
     }
     
-    private function readSignedExpGolomb(sps:BitArray):uint {
+    public function readSignedExpGolomb(sps:BitArray):uint {
         var r:uint = this.readUnsignedExpGolomb();
         if (r & 0x01) {
             r = (r+1) >> 1;

--- a/src/com/axis/rtspclient/BitArray.as
+++ b/src/com/axis/rtspclient/BitArray.as
@@ -49,7 +49,7 @@ package com.axis.rtspclient {
       return n - 1; /* Because result in exp golomb is one larger */
     }
     
-    public function readSignedExpGolomb(sps:BitArray):uint {
+    public function readSignedExpGolomb():uint {
         var r:uint = this.readUnsignedExpGolomb();
         if (r & 0x01) {
             r = (r+1) >> 1;

--- a/src/com/axis/rtspclient/FLVMux.as
+++ b/src/com/axis/rtspclient/FLVMux.as
@@ -133,8 +133,9 @@ package com.axis.rtspclient {
         var seq_scaling_matrix_present_flag:uint = sps.readBits(1);
 
         if (seq_scaling_matrix_present_flag) {
-          var i:uint  =0;
-          for (i = 0; i < 8; i++) {
+          var i:uint = 0;
+          var loopCount: uint = (3 === chroma_format_idc) ? 12 : 8;
+          for (i = 0; i < loopCount; i++) {
             var seq_scaling_list_present_flag:uint = sps.readBits(1);
             if (seq_scaling_list_present_flag) {
               var sizeOfScalingList:uint = (i < 6) ? 16 : 64;

--- a/src/com/axis/rtspclient/FLVMux.as
+++ b/src/com/axis/rtspclient/FLVMux.as
@@ -106,7 +106,6 @@ package com.axis.rtspclient {
       return 1 + 2 + contents.length;
     }
 
-
     private function parseSPS(sps:BitArray):Object {
       var nalhdr:uint      = sps.readBits(8);
 

--- a/src/com/axis/rtspclient/FLVMux.as
+++ b/src/com/axis/rtspclient/FLVMux.as
@@ -106,15 +106,6 @@ package com.axis.rtspclient {
       return 1 + 2 + contents.length;
     }
 
-    private function readSE(sps:BitArray):uint {
-        var r:uint = sps.readUnsignedExpGolomb();
-        if (r & 0x01) {
-            r = (r+1)/2;
-        } else {
-            r = -(r/2);
-        }
-        return r;
-    }
 
     private function parseSPS(sps:BitArray):Object {
       var nalhdr:uint      = sps.readBits(8);
@@ -152,7 +143,7 @@ package com.axis.rtspclient {
               var j:uint = 0;
               for (j = 0; j < sizeOfScalingList; j++) {
                 if (nextScale != 0) {
-                  var delta_scale:uint = readSE(sps);
+                  var delta_scale:uint = sps.readSignedExpGolomb();
                   nextScale = (lastScale + delta_scale + 256) % 256;
                 }
                 lastScale = (nextScale == 0) ? lastScale : nextScale;


### PR DESCRIPTION
When I try to watch streams proxied by gstreamer from my cameras I got 822 error. So I added scale matrix reading code. Not sure if it fully correct cause I don't know much about h264 and what this scaling matrix is and just copy-paste this part from working example. But now all my streams now playing.