### PR TITLE
Stream status current time

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,13 +165,13 @@ locomote.destroy();
 > - fps - frames per second.
 > - resolution (object) - the stream size `{ width, height }`.
 > - playbackSpeed - current playback speed. 1.0 is normal stream speed.
-> - current time - ms from start of stream.
+> - currentTime - seconds from start of stream.
 > - protocol - which high-level transport protocol is in use.
 > - audio (bool) - if the stream contains audio.
 > - video (bool) - if the stream contains video.
 > - state - current playback state (playing, paused, stopped).
 > - streamURL - the source of the current media.
-> - duration - the duration of the currently playing media)
+> - duration - the duration of the currently playing media in seconds.
 
 #### playerStatus()
 

--- a/src/Player.as
+++ b/src/Player.as
@@ -313,7 +313,8 @@ package {
         'video': (this.client) ? this.streamHasVideo : null,
         'state': this.currentState,
         'streamURL': (this.urlParsed) ? this.urlParsed.full : null,
-        'duration': meta.duration ? meta.duration : null
+        'duration': meta.duration ? meta.duration : null,
+        'currentTime' : (this.client) ? this.client.currentTime() : null
       };
 
       return status;

--- a/src/com/axis/IClient.as
+++ b/src/com/axis/IClient.as
@@ -72,5 +72,11 @@ package com.axis {
      * Returns the current achieved frames per second for the client.
      */
     function currentFPS():Number;
+
+    /**
+     * The position of the playhead, in seconds as the duration.
+     */
+    function currentTime():Number;
+
   }
 }

--- a/src/com/axis/NetStreamClient.as
+++ b/src/com/axis/NetStreamClient.as
@@ -34,6 +34,10 @@ package com.axis {
       return Math.floor(this.ns.currentFPS + 0.5);
     };
 
+    public function currentTime():Number {
+      return this.ns.time;
+    };
+
     protected function setupNetStream():void {
       this.ns.bufferTime = Player.config.buffer;
       this.ns.client = this;

--- a/src/com/axis/mjpegclient/MJPEGClient.as
+++ b/src/com/axis/mjpegclient/MJPEGClient.as
@@ -84,6 +84,11 @@ package com.axis.mjpegclient {
       return mjpeg.getFps();
     };
 
+    public function currentTime():Number {
+      /* not yet implemented : mjpeg.getCurrentTime() */
+      return null;
+    };
+
     private function onDisconnect(e:Event):void {
       mjpeg.clear();
       dispatchEvent(new ClientEvent(ClientEvent.STOPPED));


### PR DESCRIPTION
This is an implementation of the stream status current time. It use second as unit as the duration. 

This is like the pull request of the 29th of January but using the same unit of time as the duration.
