### PR TITLE
Add possibility to load a custom policy file

### DIFF
--- a/jslib/locomote.js
+++ b/jslib/locomote.js
@@ -194,6 +194,11 @@
       return this;
     },
 
+    loadPolicyFile: function(url) {
+      this.e.loadPolicyFile(url);
+      return this;
+    },
+
     on: function(eventName, callback) {
       this.callbacks.push({ eventName: eventName, callback: callback });
 

--- a/src/Player.as
+++ b/src/Player.as
@@ -123,6 +123,7 @@ package {
       ExternalInterface.addCallback("muteMicrophone", muteMicrophone);
       ExternalInterface.addCallback("unmuteMicrophone", unmuteMicrophone);
       ExternalInterface.addCallback("setConfig", setConfig);
+      ExternalInterface.addCallback("loadPolicyFile", loadPolicyFile);
 
       /* Audio Transmission API */
       ExternalInterface.addCallback("startAudioTransmit", startAudioTransmit);
@@ -195,6 +196,11 @@ package {
       }
     }
 
+    public function loadPolicyFile(url:String):String {
+      Security.loadPolicyFile(url);
+      return "ok";
+    }
+
     public function play(param:* = null):void {
       this.streamHasAudio = false;
       this.streamHasVideo = false;
@@ -252,7 +258,7 @@ package {
         ErrorManager.dispatchError(811, [urlParsed.protocol])
         return;
       }
-        
+
       addChild(this.client.getDisplayObject());
 
       client.addEventListener(ClientEvent.STOPPED, onStopped);


### PR DESCRIPTION
Since Locomote use Socket, Flash try to get the the policy file from the host on port 843.

This change add the possibility to load a custom policy file. It could be very helpful if you want to load the cross-domain policy file on a different port. If you work in business environment with all ports locked (except the standard ones) this could help you use locomote anyway.

In our company we use HaProxy and it very easy to handle the cross-domain request from flash on port 80 for example. I can post a configuration file if someone is interested.