### PR TITLE
Implemented support for Foscam cameras.  Fixes #151

### DIFF
--- a/src/com/axis/rtspclient/FLVMux.as
+++ b/src/com/axis/rtspclient/FLVMux.as
@@ -305,6 +305,15 @@ package com.axis.rtspclient {
           depth: 0x1, /* 16 bits per sample, but why? */
           type: 0x0 /* Mono */
         };
+        
+      case 'pcmu':
+        return {
+          format: 0x8, /* Logarithmic G.711 mu-law  */
+          sampling: 0, /* Doesn't matter. Rate is fixed at 8 kHz when format = 0x8 */
+          depth: 1, /* 16 bits per sample */
+          type: 0 /* Mono */
+        };        
+
       default:
         return false;
       }

--- a/src/com/axis/rtspclient/RTSPClient.as
+++ b/src/com/axis/rtspclient/RTSPClient.as
@@ -235,9 +235,10 @@ package com.axis.rtspclient {
 
         Logger.log('RTSPClient: switching authorization from ' + authState + ' to ' + newAuthState);
         authState = newAuthState;
-        state = STATE_INITIAL;
-        data = new ByteArray();
-        handle.reconnect();
+        
+        requestReset();
+        prevMethod();
+
         return false;
       }
 
@@ -351,6 +352,7 @@ package com.axis.rtspclient {
         this.addEventListener("VIDEO_H264_PACKET", analu.onRTPPacket);
         this.addEventListener("AUDIO_MPEG4-GENERIC_PACKET", aaac.onRTPPacket);
         this.addEventListener("AUDIO_PCMA_PACKET", apcma.onRTPPacket);
+        this.addEventListener("AUDIO_PCMU_PACKET", apcma.onRTPPacket);
         analu.addEventListener(NALU.NEW_NALU, flvmux.onNALU);
         aaac.addEventListener(AACFrame.NEW_FRAME, flvmux.onAACFrame);
         apcma.addEventListener(PCMAFrame.NEW_FRAME, flvmux.onPCMAFrame);
@@ -464,8 +466,9 @@ package com.axis.rtspclient {
 
     private function sendOptionsReq():void {
       state = STATE_OPTIONS;
+      var u:String = 'rtsp://' + urlParsed.host + urlParsed.urlpath;      
       var req:String =
-        "OPTIONS * RTSP/1.0\r\n" +
+        "OPTIONS " + u + " RTSP/1.0\r\n" +
         "CSeq: " + (++cSeq) + "\r\n" +
         "User-Agent: " + userAgent + "\r\n" +
         "\r\n";

--- a/src/com/axis/rtspclient/SDP.as
+++ b/src/com/axis/rtspclient/SDP.as
@@ -88,6 +88,8 @@ package com.axis.rtspclient {
 
       media[currentMediaBlock.type] = currentMediaBlock;
 
+      setWellKnownPayloadTypes();
+
       return success;
     }
 
@@ -226,6 +228,27 @@ package com.axis.rtspclient {
       }
 
       return true;
+    }
+
+    /**
+    Look for media blocks that do not have an rtpmap entry, and have a pt that corresponds to
+    a well known media type from http://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml
+    Some servers/cameras will not specify "a=rtpmap" for well known types, and this code will fill in the rtpmap in 
+    those cases.
+    */
+    private function setWellKnownPayloadTypes():void {
+      for each (var mediaBlock:Object in media) {
+        if(null == mediaBlock.rtpmap[mediaBlock.fmt]) {
+          if(0 == mediaBlock.fmt && "audio" == mediaBlock.type) {
+          
+            var payloadType:Object = new Object();
+            payloadType.name  = "PCMU";
+            payloadType.clock = 8000;
+
+            mediaBlock.rtpmap[mediaBlock.fmt] = payloadType;
+          }
+        }
+      }
     }
 
     public function getSessionBlock():Object {


### PR DESCRIPTION
Hi, I've implemented some basic support for Foscam cameras.  In particular, this works with the FI9828P model that I have.  I'm hoping that these changes do not cause any regressions with cameras/servers that currently work with Locomote.

The video now works fine with my camera.  However, audio quality is very poor, and I suspect that there may be some Flash Video Player compatibility issue with the G.726 audio codec that this camera uses.

---
- Don't use wildcard in OPTIONS request. This freaks out some servers/cameras.
- Don't close the connection following an auth switch. This invalidates the nonce on certain servers/cameras and then you cannot login.
- Added handlers for PCMU audio.
- Added default insertion of well-known audio type 0 (PCMU) since servers/cameras may not include an a=rtpmap in the description for pre-defined types.
