### PR TITLE
Add HTTP Auth support to MJPEG client (multipart)

### DIFF
--- a/src/com/axis/http/auth.as
+++ b/src/com/axis/http/auth.as
@@ -61,7 +61,7 @@ package com.axis.http {
           /* No authorization attempt yet, try with the best method supported by server */
           if (authOpts.digestRealm)
             return 'digest';
-          else if (authOpts.basicRealm)
+          else if (authOpts.hasOwnProperty('basicRealm'))
             return 'basic';
           break;
 

--- a/src/com/axis/http/request.as
+++ b/src/com/axis/http/request.as
@@ -64,7 +64,7 @@ package com.axis.http {
             hdr['www-authenticate'] = {};
 
           if (/^basic/i.test(val)) {
-            var basicRealm:RegExp = /realm=\"([^\"]+)\"/i;
+            var basicRealm:RegExp = /realm="([^"]*)"/i;
             hdr['www-authenticate'].basicRealm = basicRealm.exec(val)[1];
           }
 


### PR DESCRIPTION
Basically, stripped from RTSP client. Includes minor modifications to header parsing and authentication selection.