### PR TITLE
If no swfready property, instance has been destroyed

### DIFF
--- a/jslib/locomote.js
+++ b/jslib/locomote.js
@@ -25,7 +25,8 @@
     }
 
     // Instance already initialized. Return it.
-    if (window.LocomoteMap[tag]) {
+    if (window.LocomoteMap[tag] &&
+        window.LocomoteMap[tag].swfready) {
       return window.LocomoteMap[tag];
     }
 


### PR DESCRIPTION
If there is not `swfready` property in current instance -- it has been destroyed earlier and must be re-initialized.