### PR TITLE
MJPEGClient closing socket twice

### DIFF
--- a/src/com/axis/mjpegclient/Handle.as
+++ b/src/com/axis/mjpegclient/Handle.as
@@ -70,27 +70,7 @@ package com.axis.mjpegclient {
     }
 
     public function disconnect():void {
-      Logger.log('MJPEGClient: disconnecting from', urlParsed.host + ':' + urlParsed.port);
-
-      // The close event on the socket is often not called so do all cleanup
-      // immediately.
-      if (this.bcTimer) {
-        this.bcTimer.stop();
-        this.bcTimer.removeEventListener(TimerEvent.TIMER_COMPLETE, bcTimerHandler);
-        this.bcTimer = null;
-      }
-
-      this.buffer = null;
-
-      try {
-        // Security error is thrown if this line is excluded
-        socket.close();
-      } catch (error:*) {}
-
-      if (!this.closeTiggered) {
-        dispatchEvent(new Event(Handle.CLOSED));
-        this.closeTiggered = true;
-      }
+      dispatchEvent(new Event(Event.CLOSE));
     }
 
     public function connect():void {

--- a/src/com/axis/mjpegclient/Handle.as
+++ b/src/com/axis/mjpegclient/Handle.as
@@ -70,6 +70,7 @@ package com.axis.mjpegclient {
     }
 
     public function disconnect():void {
+      Logger.log('MJPEGClient: disconnecting from', urlParsed.host + ':' + urlParsed.port);
       dispatchEvent(new Event(Event.CLOSE));
     }
 


### PR DESCRIPTION
`disconnect()` and `onClose()` have exactly same code. And `disconnect()` eventually invokes `onClose()`, socket is being closed twice and error occur. I made it so that `disconnect()` dispatches event which `onClose()` handles.