### PR TITLE
fix build with node > 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gulp-jscs": "^1.3.1",
     "gulp-uglify": "^1.0.1",
     "gulp-rename": "^1.2.0",
-    "gulp-git": "^0.5.5",
+    "gulp-git": "^2.5.2",
     "gulp-bump": "^0.1.11",
     "yargs": "^1.3.3"
   },


### PR DESCRIPTION
Project is not compiling anymore with node > 6.

It now works with node 9.x