### PR TITLE
Fix 'Gitter' badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Locomote Video Player [![Build Status](https://travis-ci.org/AxisCommunications/locomote-video-player.svg?branch=master)](https://travis-ci.org/AxisCommunications/locomote-video-player) [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/AxisCommunications/locomote-video-player?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# Locomote Video Player [![Build Status](https://travis-ci.org/AxisCommunications/locomote-video-player.svg?branch=master)](https://travis-ci.org/AxisCommunications/locomote-video-player) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/AxisCommunications/locomote-video-player?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Getting started
 


### PR DESCRIPTION
Was browsing the repository and saw that the badge for Gitter did not display properly. Adding "%20" instead of space seems to fix this issue. 

Change-Id: I605ddd29ebe51a7fa240a777c00c420b1f5244a5